### PR TITLE
Updated CGo bindings to be compliant with Go 1.6 requirements

### DIFF
--- a/ext/bindings.go
+++ b/ext/bindings.go
@@ -10,14 +10,14 @@ import (
 func main() {}
 
 //export import_cat1
-func import_cat1(rawPath *C.char) string {
+func import_cat1(rawPath *C.char) *C.char {
 	path := C.GoString(rawPath)
-	return importer.Read_patient(path)
+	return C.CString(importer.Read_patient(path))
 }
 
 //export generateCat1
-func generateCat1(patient *C.char, measures *C.char) string {
+func generateCat1(patient *C.char, measures *C.char) *C.char {
 	patientbytes := []byte(C.GoString(patient))
 	measuresbytes := []byte(C.GoString(measures))
-	return exporter.GenerateCat1(patientbytes, measuresbytes)
+	return C.CString(exporter.GenerateCat1(patientbytes, measuresbytes))
 }


### PR DESCRIPTION
Go 1.6 has much stricter requirements as to what can be passed to/from C and Go using the CGo library (see https://golang.org/cmd/cgo/#hdr-Passing_pointers). We were running into Go panics because we were trying to pass a Go pointer back to C code. 

The fix is to pass a C pointer back to the C code instead.
