### PR TITLE
Export sync

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -1,5 +1,9 @@
 build:
-	go build -a -buildmode=c-shared -o libgocda.so bindings.go
+ifeq ($(shell uname), Darwin)
+	go build -a -buildmode=c-shared -o libgocda-mac.so bindings.go
+else
+	go build -a -buildmode=c-shared -o libgocda-linux.so bindings.go
+endif
 
 # fake out clean and install
 clean:

--- a/ext/libgocda-mac.h
+++ b/ext/libgocda-mac.h
@@ -11,6 +11,7 @@
 
 
 /* Start of boilerplate cgo prologue.  */
+#line 1 "cgo-gcc-export-header-prolog"
 
 #ifndef GO_CGO_PROLOGUE_H
 #define GO_CGO_PROLOGUE_H

--- a/lib/go-cda-tools/export/go-exporter.rb
+++ b/lib/go-cda-tools/export/go-exporter.rb
@@ -5,14 +5,19 @@ module GoCDATools
   module Export
     class GoExporter
       include Singleton
-      # extend FFI::Library
-        # ffi_lib File.expand_path("../../../ext/libgocda.so", File.dirname(__FILE__))
-        # attach_function :generateCat1, [:string, :string], :string
+      extend FFI::Library
+        if OS.linux?
+          ffi_lib File.expand_path("../../../ext/libgocda-linux.so", File.dirname(__FILE__))
+        end
+        
+        if OS.mac?
+          ffi_lib File.expand_path("../../../ext/libgocda-mac.so", File.dirname(__FILE__))
+        end
+        # attach_function :GenerateCat1, [:string, :string], :string
         #
         # def export_with_ffi(obj, mes)
-        #   generateCat1(obj, mes)
+        #   GenerateCat1(obj, mes)
         # end
-
     end
   end
 end


### PR DESCRIPTION
- Add OS detection to `Make build` and to go exporter so we don't need to customize the command for Mac and Linux builds
