### PR TITLE
Update Makefile to also pull in CDATools

### DIFF
--- a/ext/Makefile
+++ b/ext/Makefile
@@ -10,7 +10,7 @@ clean:
 install:
 
 dependencies:
-	go get github.com/jbowtie/gokogiri/xml github.com/pborman/uuid
+	go get -u github.com/jbowtie/gokogiri/xml github.com/pborman/uuid github.com/projectcypress/cdatools/...
 	bundle install
 
 


### PR DESCRIPTION
Also make the make dependencies command always pull the latest versions whenever `make dependencies` is run, with the assumption that if the user is explicitly requesting dependencies then they most likely want the most up to date versions.