### PR TITLE
Add workaround for birthdate zero bug

### DIFF
--- a/lib/go-cda-tools/import/go-importer.rb
+++ b/lib/go-cda-tools/import/go-importer.rb
@@ -22,6 +22,11 @@ module GoCDATools
             raise patient_json_string
           end
           patient = Record.new(JSON.parse(patient_json_string))
+
+          # FIXME: This is here because QME has a bug where patients don't calculate accurately if birthdate is exactly 0 (01/01/1970)
+          #        The plan is to remove this once Cypress integrates CQL and no longer relies on QME for calculation
+          patient.birthdate += 1 if patient.birthdate == 0
+
           # When imported from go, conditions that are unresolved need to have a stop_time added
           update_conditions(patient)
           # When imported from go, entry ids need to be updated to reflected references


### PR DESCRIPTION
This is a workaround for a bug probably in QME where patients don't calculate correctly if their birthdate is exactly 0. This change should be reverted when Cypress switches to CQL and no longer relies on QME.